### PR TITLE
fix init when semver branch exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ git semver init
 ```
 
 This will:
+
 - create an orphaned branch named `semver`.
 - create and commit a single file named after your current branch, i.e. `master`, with the content of `0.0.0`.
 - move this new checkout to `.semver` in your current repository
@@ -66,8 +67,6 @@ From [scope/scope.go](scope/scope.go), these values have default values that can
 - `SEMVER_PRE_PREFIX  = pre`
 - `SEMVER_USER_EMAIL  = semver@semver.org`
 - `SEMVER_USER_NAME   = semver`
-
-
 
 Additionally, `$SEMVER_BRANCH` (then `$GIT_BRANCH` if empty, then `$BRANCH_NAME`) will be dereferenced if `git-semver` is unable to detect the current branch (common with the default clone/checkout in Jenkins).
 

--- a/main.go
+++ b/main.go
@@ -101,6 +101,8 @@ func main() {
 	}
 	if sv, err = scope.Init(my, _init.Parsed()); err != nil {
 		log.Fatalf("%s: %v", cmd, err)
+	} else if _init.Parsed() {
+		return
 	}
 
 	switch {
@@ -121,10 +123,12 @@ func main() {
 		if err = scope.Tag(my, sv); err != nil {
 			log.Fatalf("%s: %v", cmd, err)
 		}
-		// do 'git-semver push'
 	case _push.Parsed():
+		// do 'git-semver push'
+		cmd = _push.Name()
+
 		if err = scope.Push(my, sv); err != nil {
-			log.Fatalf("%s: %v", cmd, fmt.Errorf("failed to push: %v", err))
+			log.Fatalf("%s: %v", cmd, err)
 		}
 	default:
 		if ver, err := scope.ReadVersion(my, sv); err != nil {

--- a/scope/push.go
+++ b/scope/push.go
@@ -11,7 +11,7 @@ import (
 
 // Push the semver branch and any tags to the remote.
 func Push(my, sv *Extent) error {
-	err := sv.Repo.Push(&git.PushOptions{
+	var err = sv.Repo.Push(&git.PushOptions{
 		RemoteName: RemoteName,
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("refs/heads/semver:refs/heads/semver"),


### PR DESCRIPTION
this fix addresses edgexfoundry/git-semver#8

additionally, init on a repository lacking a semver branch on the
remote will no longer attempt to push the newly created semver
branch to the remote.

invoking init is meant to be idempotent, converging on having
- the `semver` branch checked out in the `.semver` directory
- a committed file in the `.semver` directory matching the name
  of the current branch
- if the `.semver` checkout is missing a remote, set the origin
  from the current repository if available

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>