### PR TITLE
use git-default author/committer envvars

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dweomer/go-git v0.0.0-20190319204522-c7d3d2a65c77 h1:QOVTk2GzapNmai9QNQr7xjofRpdQhc5n+DdEnWCAfsQ=
-github.com/dweomer/go-git v0.0.0-20190319204522-c7d3d2a65c77/go.mod h1:Vtut8izDyrM8BUVQnzJ+YvmNcem2J89EmfZYCkLokZk=
 github.com/emirpasic/gods v1.9.0 h1:rUF4PuzEjMChMiNsVjdI+SyLu7rEqpQ5reNFnhC7oFo=
 github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
@@ -32,6 +30,8 @@ github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnG
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/otiai10/copy v1.0.1 h1:gtBjD8aq4nychvRZ2CyJvFWAw0aja+VHazDdruZKGZA=
 github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.2.3 h1:PsrRBmrxR68kyNu6YlqYHbNlItc5vOkuS6LBEsNttVA=
 github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -38,10 +38,18 @@ var (
 	PrePrefix = GetEnv("SEMVER_PRE_PREFIX", "pre")
 
 	// UserEmail is the value for the git config user.email in the local semver repository.
-	UserEmail = GetEnv("SEMVER_USER_EMAIL", "semver@semver.org")
+	UserEmail = GetEnv("SEMVER_USER_EMAIL",
+		GetEnv("GIT_AUTHOR_EMAIL",
+			GetEnv("GIT_COMMITTER_EMAIL", "semver@semver.org"),
+		),
+	)
 
 	// UserName is the value for the git config user.name in the local semver repository.
-	UserName = GetEnv("SEMVER_USER_NAME", "semver")
+	UserName = GetEnv("SEMVER_USER_NAME",
+		GetEnv("GIT_AUTHOR_NAME",
+			GetEnv("GIT_COMMITTER_NAME", "semver"),
+		),
+	)
 )
 
 // Extent is an Open()'ed GIT repository.


### PR DESCRIPTION
- try `$SEMVER_USER_EMAIL`, `$GIT_AUTHOR_EMAIL`, `$GIT_COMMITTER_EMAIL` before using the default for object.Signature.Email
- try `$SEMVER_USER_NAME`, `$GIT_AUTHOR_NAME`, `$GIT_COMMITTER_NAME` before using the default for object.Signature.Name

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>