### PR TITLE
Add unit tests to increase code coverage

### DIFF
--- a/scope/bump.go
+++ b/scope/bump.go
@@ -10,7 +10,7 @@ import (
 
 // Bump the specified semver axis with prefix, invoking WriteVersion on the result.
 func Bump(my, sv *Extent, axis, pre string) error {
-	ver, err := ReadVersion(my, sv)
+	ver, err := _ReadVersion(my, sv)
 	if err != nil {
 		return err
 	}
@@ -39,5 +39,5 @@ func Bump(my, sv *Extent, axis, pre string) error {
 	if err != nil {
 		return err
 	}
-	return WriteVersion(my, sv, ver)
+	return _WriteVersion(my, sv, ver)
 }

--- a/scope/bump_test.go
+++ b/scope/bump_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scope
+
+import (
+	"fmt"
+	"errors"
+	"github.com/blang/semver"
+	"testing"
+)
+
+var (
+	bumpReadError  = errors.New("Read Error")
+	__ReadVersion  = _ReadVersion
+	__WriteVersion = _WriteVersion
+)
+
+func TestBump_ReadVersionError(t *testing.T) {
+	// Bump Should return error When ReadVersion error
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = func(my, sv *Extent) (Version, error) {
+		return Version{}, bumpReadError
+	}
+	gotError := Bump(myExtentMock, svExtentMock, "major", "")
+	if gotError != bumpReadError {
+		t.Errorf("Failed to return expected error")
+	}
+}
+
+func TestBump_Major(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping major axis
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "major", "")
+	if gotError.Error() != "WriteVersion 2.0.0" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_Minor(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping minor axis
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "minor", "")
+	if gotError.Error() != "WriteVersion 1.3.0" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_Patch(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping patch axis
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "patch", "")
+	if gotError.Error() != "WriteVersion 1.2.4" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_Final(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping final axis
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "final", "")
+	if gotError.Error() != "WriteVersion 1.2.3" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_PreDev(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping pre axis with pre override with same name
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "pre", "dev")
+	if gotError.Error() != "WriteVersion 1.2.3-dev.5" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_PreOverride(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping pre axis with pre override with different name
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "pre", "pre")
+	if gotError.Error() != "WriteVersion 1.2.3-pre.1" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_PreNoPre(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping pre axis with no pre
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "pre", "")
+	if gotError.Error() != "WriteVersion 1.2.4-pre.1" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_PrePre(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping pre axis with pre no override
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.1")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "pre", "")
+	fmt.Printf("%v\n", gotError)
+	if gotError.Error() != "WriteVersion 1.2.3-dev.2" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_PreBug(t *testing.T) {
+	// Bump Should return WriteVersion result When bumping pre axis with no pre and override
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "pre", "bug")
+	if gotError.Error() != "WriteVersion 1.2.4-bug.1" {
+		t.Errorf("Failed WriteVersion did not receive expected arguments")
+	}
+}
+
+func TestBump_NotSupported(t *testing.T) {
+	// Bump Should return error When bumping unsupported axis
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	defer func() {
+		_ReadVersion = __ReadVersion
+	}()
+	_ReadVersion = ReadVersionMock("1.2.3-dev.4")
+	defer func() {
+		_WriteVersion = __WriteVersion
+	}()
+	_WriteVersion = WriteVersionMock
+	gotError := Bump(myExtentMock, svExtentMock, "notsupported", "")
+	if gotError == nil {
+		t.Errorf("Failed to return expected error")
+	}
+}
+
+func TestBump(t *testing.T) {
+	// Table-Driven tests for Bump containing most of the test cases above
+	myExtentMock := &Extent{}
+	svExtentMock := &Extent{}
+	tests := []struct {
+		name       	string
+		versionStr	string
+		axis		string
+		pre			string
+		wantError	string
+	}{
+		{
+			name: "Bump Should return WriteVersion result When bumping major axis",
+			versionStr: "1.2.3-dev.4",
+			axis: "major",
+			pre: "",
+			wantError: "WriteVersion 2.0.0",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping minor axis",
+			versionStr: "1.2.3-dev.4",
+			axis: "minor",
+			pre: "",
+			wantError: "WriteVersion 1.3.0",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping patch axis",
+			versionStr: "1.2.3-dev.4",
+			axis: "patch",
+			pre: "",
+			wantError: "WriteVersion 1.2.4",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping final axis",
+			versionStr: "1.2.3-dev.4",
+			axis: "final",
+			pre: "",
+			wantError: "WriteVersion 1.2.3",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping pre axis with pre override with same name",
+			versionStr: "1.2.3-dev.4",
+			axis: "pre",
+			pre: "dev",
+			wantError: "WriteVersion 1.2.3-dev.5",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping pre axis with pre override with different name",
+			versionStr: "1.2.3-dev.4",
+			axis: "pre",
+			pre: "pre",
+			wantError: "WriteVersion 1.2.3-pre.1",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping pre axis with no pre",
+			versionStr: "1.2.3",
+			axis: "pre",
+			pre: "",
+			wantError: "WriteVersion 1.2.4-pre.1",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping pre axis with pre no override",
+			versionStr: "1.2.3-dev.1",
+			axis: "pre",
+			pre: "",
+			wantError: "WriteVersion 1.2.3-dev.2",
+		}, {
+			name: "Bump Should return WriteVersion result When bumping pre axis with no pre and override",
+			versionStr: "1.2.3",
+			axis: "pre",
+			pre: "bug",
+			wantError: "WriteVersion 1.2.4-bug.1",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				_ReadVersion = __ReadVersion
+			}()
+			_ReadVersion = ReadVersionMock(test.versionStr)
+			defer func() {
+				_WriteVersion = __WriteVersion
+			}()
+			_WriteVersion = WriteVersionMock
+			gotError := Bump(myExtentMock, svExtentMock, test.axis, test.pre)
+			if gotError.Error() != test.wantError {
+				t.Errorf("Failed WriteVersion did not receive expected arguments")
+			}
+		})
+	}
+}
+
+func ReadVersionMock(versionStr string) func(my, sv *Extent) (Version, error) {
+	f := func(my, sv *Extent) (Version, error) {
+		version, _ := semver.Parse(versionStr)
+		return version, nil
+	}
+	return f
+}
+
+func WriteVersionMock(my, sv *Extent, ver Version) error {
+	return errors.New(
+		fmt.Sprintf("WriteVersion %v", ver))
+}

--- a/scope/read.go
+++ b/scope/read.go
@@ -5,9 +5,9 @@
 package scope
 
 import (
-	"io/ioutil"
 	"strings"
 )
+
 
 // ReadVersion reads the semver version for the current branch.
 func ReadVersion(my, sv *Extent) (Version, error) {
@@ -17,7 +17,7 @@ func ReadVersion(my, sv *Extent) (Version, error) {
 	}
 	defer file.Close()
 	var buf []byte
-	if buf, err = ioutil.ReadAll(file); err != nil {
+	if buf, err = ioutilReadAll(file); err != nil {
 		return Version{}, err
 	}
 	ver := strings.TrimRight(string(buf), "\n\r")

--- a/scope/read_test.go
+++ b/scope/read_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scope
+
+import (
+	"io"
+	"errors"
+	"github.com/blang/semver"
+	"gopkg.in/src-d/go-billy.v4/memfs"
+	"gopkg.in/src-d/go-git.v4"
+	"testing"
+)
+
+var (
+	readError  = errors.New("Read Error")
+	__ioutilReadAll = ioutilReadAll
+)
+
+func TestReadVersion_OpenError(t *testing.T) {
+	// ReadVersion Should return expected When Open returns an error
+	myExtentMock := &Extent{
+		Branch: "testbranch",
+	}
+	svExtentMock := &Extent{
+		Tree: &git.Worktree{
+			Filesystem: memfs.New(),
+		},
+	}
+
+	gotVersion, gotError := ReadVersion(myExtentMock, svExtentMock)
+	if gotVersion.Compare(Version{}) != 0 {
+		t.Errorf("Failed to return expected version")
+	}
+	if gotError.Error() != "file does not exist" {
+		t.Errorf("Failed to return expected error")
+	}
+}
+
+func TestReadVersion_ReadAllError(t *testing.T) {
+	// ReadVersion Should return expected When ReadAll returns an error
+	myExtentMock := &Extent{
+		Branch: "testbranch",
+	}
+	memFs := memfs.New()
+	svExtentMock := &Extent{
+		Tree: &git.Worktree{
+			Filesystem: memFs,
+		},
+	}
+	memFs.Create("testbranch")
+	defer func() {
+		ioutilReadAll = __ioutilReadAll
+	}()
+	ioutilReadAll = func(r io.Reader) ([]byte, error) {
+		return nil, readError
+	}
+	gotVersion, gotError := ReadVersion(myExtentMock, svExtentMock)
+	if gotVersion.Compare(Version{}) != 0 {
+		t.Errorf("Failed to return expected version")
+	}
+	if gotError != readError {
+		t.Errorf("Failed to return expected error")
+	}
+}
+
+func TestReadVersion(t *testing.T) {
+	// ReadVersion Should return expected When no error
+	myExtentMock := &Extent{
+		Branch: "testbranch",
+	}
+	memFs := memfs.New()
+	svExtentMock := &Extent{
+		Tree: &git.Worktree{
+			Filesystem: memFs,
+		},
+	}
+	file, _ := memFs.Create("testbranch")
+	data := []byte("0.0.1-test.1")
+	file.Write(data)
+	file.Close()
+	gotVersion, gotError := ReadVersion(myExtentMock, svExtentMock)
+	wantVersion, _ := semver.Parse("0.0.1-test.1")
+	if gotVersion.Compare(wantVersion) != 0 {
+		t.Errorf("Failed to return expected version")
+	}
+	if gotError != nil {
+		t.Errorf("Failed returned error not expected")
+	}
+}

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -20,6 +20,10 @@ import (
 
 var (
 	log = golog.New(ioutil.Discard, "", 0)
+	// variables representing patchable functions
+	ioutilReadAll = ioutil.ReadAll
+	_ReadVersion = ReadVersion
+	_WriteVersion = WriteVersion
 )
 
 func init() {


### PR DESCRIPTION
Added the following unit tests to get coverage up to 25%. 

My approach was to add unit tests without modifying the source code, however IMHO in order to unit test the remaining functions and methods will require refactoring the source code to make it **testable**. What I mean by testable is essentially refactoring the code to facilitate the mocking of  dependencies.

The patterns to implement to make the code more testable are described in the following article:
https://husobee.github.io/golang/testing/unit-test/2015/06/08/golang-unit-testing.html

- **Monkey Patching**
This pattern can be used for testing/mocking third party function calls.. Go has first class functions, thus assign the third party function to a variable defined at the package then in test override the variable to point to a function in your test package that returns the desired output.

- **Mocking Struct Methods via Interfacing**
This pattern can be used for testing/mocking methods of struct dependencies. Define an interface consisting of all methods that are called on the dependent struct. Include a get function that returns the interface (in lieu of returning the dependent struct). In test, create a struct that mocks the dependent struct and implement all the methods defined by the interface returning the desired (i.e. mocked) output. When overriding the get function in test return the address of the mock struct instead. Go will not complain because the mocked struct implements the same interface as in the actual code.

- **Using composition**
This pattern may be used to help us test the Extent struct. This involves composing larger interfaces from smaller ones through embedding, enabling us to control the methods which we do want to change while still being able to test the ones we don’t want to change.

I plan to review my findings as well as get recommendations from a resident Go developer, will use that output to create a new user story to refactor git-semver for testability user story.

The following repository contains sample code and unit tests showing how the patterns described above can be applied, writing sample code and unit tests made the concepts resonate with me: 
https://github.com/soda480/go-unit-test-example

The test fixture pattern used to mock the Worktree Filesystem was inspired by reviewing test code from: https://github.com/src-d/go-git/blob/v4.13.1/worktree_test.go#L157
I would have preferred to mock all filesystem access completely, but given how things were currently defined I wasn't sure how to do that without refactoring to use interfaces. However, being that others are using memory to mock filesystem this seemed like a reasonable alternative.

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>