### PR TITLE
Update bump to echo bumped version to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func main() {
 		if err = scope.Bump(my, sv, _bump.Args()[0], pre); err != nil {
 			log.Fatalf("%s: %v", cmd, err)
 		}
+		echoVersion(my, sv, cmd)
 	case _tag.Parsed():
 		// do 'git-semver tag'
 		cmd = _tag.Name()
@@ -131,11 +132,7 @@ func main() {
 			log.Fatalf("%s: %v", cmd, err)
 		}
 	default:
-		if ver, err := scope.ReadVersion(my, sv); err != nil {
-			log.Fatalf("%s: %v", cmd, err)
-		} else {
-			fmt.Fprintln(os.Stdout, ver)
-		}
+		echoVersion(my, sv, cmd)
 	}
 }
 
@@ -145,4 +142,12 @@ func fail(err error, usage func()) {
 		usage()
 	}
 	os.Exit(1)
+}
+
+func echoVersion(my, sv *scope.Extent, cmd string) {
+	if ver, err := scope.ReadVersion(my, sv); err != nil {
+		log.Fatalf("%s: %v", cmd, err)
+	} else {
+		fmt.Fprintln(os.Stdout, ver)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

Our initial plan was to fix the git-semver issues only after we added unit tests to increase the code coverage, our thinking was that the increased test coverage would facilitate future changes by providing us confidence that any new changes didn't break anything. This still needs to happen! However, as I was stepping through (i.e. learning) the code, I realized that some of the issues (like this one) can be resolved with minimal changes to the code. Confidence in this change was provided by executing thorough functional tests (see the notes below).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#35 

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information

**Unit Tests**
Unit tests were not added because the underlying data structure as it is currently defined has been deemed not testable (its not mockable)). Since the method that was added to echo the bumped version requires the underlying struct as arguments there was no way to unit test the code that was added in this PR. See the following closed PR for details regarding the testability of the underlying struct: https://github.com/edgexfoundry/git-semver/pull/37

**Functional Tests**
I executed functional tests to 
1. ensure the added functionality works as required and 
2. that the previous functionality continued to work as expected. 

**Functional Test Results**
I used the following test repository for the git-semver tests:  https://github.com/soda480/test_us5933

The stdout of the functional tests is included.
[test.output.txt](https://github.com/edgexfoundry/git-semver/files/4226180/test.output.txt)

