### PR TITLE
Enable default version to be specified for init

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Assuming that your `$GOPATH/bin` is in your path, that's it.
 
 NOTE: As of yet, authentication is the default provided by [src-d/go-git](https://github.com/src-d/go-git), i.e. ssh-agent auth for SSH URLs.
 
-### `git semver init`
+### `git semver init [-ver=<version>]`
 
 Prepare the repository (and the current branch) for Semantic Versioning:
 
@@ -35,7 +35,7 @@ git semver init
 This will:
 
 - create an orphaned branch named `semver`.
-- create and commit a single file named after your current branch, i.e. `master`, with the content of `0.0.0`.
+- create and commit a single file named after your current branch, i.e. `master`, with the content of `0.0.0` unless a version is specified. The default version can be overridden by specifying the `-ver=<version>` flag to `init`. Note, if specified, the version must be a valid semantic version otherwise the command will return an error.
 - move this new checkout to `.semver` in your current repository
 - - modify the `.git/info/exclude` to ignore `.semver`
 - push the `semver` branch to your current `.git` repository directory as if it were a remote.

--- a/main.go
+++ b/main.go
@@ -15,13 +15,14 @@ import (
 )
 
 var (
-	dir   string
-	cli   = flag.NewFlagSet("git-semver", flag.ExitOnError)
-	_init = flag.NewFlagSet("git-semver-init", flag.ExitOnError)
-	_bump = flag.NewFlagSet("git-semver-bump", flag.ExitOnError)
-	_tag  = flag.NewFlagSet("git-semver-tag", flag.ExitOnError)
-	_push = flag.NewFlagSet("git-semver-push", flag.ExitOnError)
-	pre   string
+	dir     string
+	cli     = flag.NewFlagSet("git-semver", flag.ExitOnError)
+	_init   = flag.NewFlagSet("git-semver-init", flag.ExitOnError)
+	_bump   = flag.NewFlagSet("git-semver-bump", flag.ExitOnError)
+	_tag    = flag.NewFlagSet("git-semver-tag", flag.ExitOnError)
+	_push   = flag.NewFlagSet("git-semver-push", flag.ExitOnError)
+	pre     string
+	version string
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 		fmt.Fprintln(cli.Output())
 	}
 
+	_init.StringVar(&version, "ver", "0.0.0", "the initial version (defaults to '0.0.0' if not specified)")
 	_bump.StringVar(&pre, "pre", "", "the pre-release prefix (defaults to 'pre' if not specified when bumping 'pre')")
 
 	if err := cli.Parse(os.Args[1:]); err != nil {
@@ -99,7 +101,7 @@ func main() {
 	if my, err = scope.Open(dir); err != nil {
 		log.Fatalf("%s: %v", cmd, err)
 	}
-	if sv, err = scope.Init(my, _init.Parsed()); err != nil {
+	if sv, err = scope.Init(my, _init.Parsed(), version); err != nil {
 		log.Fatalf("%s: %v", cmd, err)
 	} else if _init.Parsed() {
 		return


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

Our initial plan was to fix the git-semver issues only after we added unit tests to increase the code coverage, our thinking was that the increased test coverage would facilitate future changes by providing us confidence that any new changes didn't break anything. This still needs to happen! However, as I was stepping through the code, I realized that some of the issues (like this one) can be resolved with minimal changes to the code. Confidence in this change was provided by executing functional tests (see the notes below).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/git-semver/issues/34

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
Unit tests were not added because the underlying data structure as it is currently defined has been deemed not testable. All the code added in this PR requires the underlying struct to be mocked which is virtually impossible. See the following closed PR for details regarding the testability of the underlying struct: https://github.com/edgexfoundry/git-semver/pull/37

**Functional Tests**
I executed functional tests to 
1. ensure the added functionality works as required and 
2. the previous functionality continued to work as expected. 

**Functional Test Results**
I used the following test repositories for the git-semver tests:  

https://github.com/soda480/test_us5931

https://github.com/soda480/test_us5931d

The stdout of the functional tests is included.
[test.output.txt](https://github.com/edgexfoundry/git-semver/files/4227487/test.output.txt)



**Summary**
| Test| Result|
| --- | --- |
| Init with invalid version should fail | Pass |
| Init with invalid usage should display usage | Pass |
| Init with valid version specified should set version | Pass |
| Init with no version specified should set default to 0.0.0 | Pass |
| Bump pre works as expected | Pass |
| Bump pre specfiy pre works as expected | Pass |
| Bump patch works as expected | Pass |
| Bump minor works as expected | Pass |
| Bump major works as expected | Pass |
| Tag works as expected | Pass |
| Push works as expected | Pass |
| Init after deleting .semver directory should retain upstream semver version | Pass |
