### PR TITLE
update go-git version to one that supports socks proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,5 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 // indirect
-	gopkg.in/src-d/go-git.v4 v4.12.0
+	gopkg.in/src-d/go-git.v4 v4.13.1
 )
-
-// UNCOMMENT BEFORE BUILDING TO MAKE src-d/go-git WORK FOR SSH URLS BEHIND A SOCKS PROXY
-// replace gopkg.in/src-d/go-git.v4 => github.com/src-d/go-git v0.0.0-20190502205309-e17ee112ca6c


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

The upstream go-git modules now supports socks5 proxy.  This PR consists of updating the go mod reference. Note all regression tests passed and results detailed below.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/git-semver/issues/33

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

To set socks5 proxy simply set an environment variable like:
```
export ALL_PROXY=socks5://<proxy-sever>:<proxy-port>
```

**Functional Tests**
I executed functional tests to 
1. ensure the added functionality works as required and 
2. the previous functionality continued to work as expected. 

**Functional Test Results**
I used the following test repositories for the git-semver tests:  
https://github.com/soda480/test_de727a

The stdout of the functional tests is included.
[test.output.txt](https://github.com/edgexfoundry/git-semver/files/4237202/test.output.txt)

**Summary**
| Test| Result|
| --- | --- |
| Init with invalid usage should display usage | Pass |
| Init with no version specified should set default to 0.0.0 | Pass |
| Bump pre works as expected | Pass |
| Bump pre specfiy pre works as expected | Pass |
| Bump patch works as expected | Pass |
| Bump minor works as expected | Pass |
| Bump major works as expected | Pass |
| Tag works as expected | Pass |
| Push works as expected | Pass |
| Init after deleting .semver directory should retain upstream semver version | Pass |
