### PR TITLE
Add ability to force set version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Assuming that your `$GOPATH/bin` is in your path, that's it.
 
 NOTE: As of yet, authentication is the default provided by [src-d/go-git](https://github.com/src-d/go-git), i.e. ssh-agent auth for SSH URLs.
 
-### `git semver init [-ver=<version>]`
+### `git semver init [-ver=<version>] [-force]`
 
 Prepare the repository (and the current branch) for Semantic Versioning:
 
@@ -37,8 +37,9 @@ This will:
 - create an orphaned branch named `semver`.
 - create and commit a single file named after your current branch, i.e. `master`, with the content of `0.0.0` unless a version is specified. The default version can be overridden by specifying the `-ver=<version>` flag to `init`. Note, if specified, the version must be a valid semantic version otherwise the command will return an error.
 - move this new checkout to `.semver` in your current repository
-- - modify the `.git/info/exclude` to ignore `.semver`
+- modify the `.git/info/exclude` to ignore `.semver`
 - push the `semver` branch to your current `.git` repository directory as if it were a remote.
+- `force` will force set the specified or default version regardless of an existing version being present.
 
 This invocation is idempotent-ish in that it will inspect your current repository and make modifications to the `semver` configuration accordingly. It will also attempt to clone (or checkout) the `semver` branch if it already exists instead of creating it anew.
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 	_push   = flag.NewFlagSet("git-semver-push", flag.ExitOnError)
 	pre     string
 	version string
+	force   *bool
 )
 
 func init() {
@@ -60,6 +61,7 @@ func init() {
 	}
 
 	_init.StringVar(&version, "ver", "0.0.0", "the initial version (defaults to '0.0.0' if not specified)")
+	force = _init.Bool("force", false, "force set the specified version")
 	_bump.StringVar(&pre, "pre", "", "the pre-release prefix (defaults to 'pre' if not specified when bumping 'pre')")
 
 	if err := cli.Parse(os.Args[1:]); err != nil {
@@ -101,7 +103,7 @@ func main() {
 	if my, err = scope.Open(dir); err != nil {
 		log.Fatalf("%s: %v", cmd, err)
 	}
-	if sv, err = scope.Init(my, _init.Parsed(), version); err != nil {
+	if sv, err = scope.Init(my, _init.Parsed(), version, *force); err != nil {
 		log.Fatalf("%s: %v", cmd, err)
 	} else if _init.Parsed() {
 		return

--- a/scope/init.go
+++ b/scope/init.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Init attempts to clone, but failing that will initialize, the semver orphan branch into .semver directory.
-func Init(my *Extent, create bool, version string) (*Extent, error) {
+func Init(my *Extent, create bool, version string, force bool) (*Extent, error) {
 	var (
 		mydir = my.Store.Filesystem().Root()
 		myurl = mydir
@@ -106,10 +106,13 @@ func Init(my *Extent, create bool, version string) (*Extent, error) {
 		return nil, err
 	}
 
-	if _, err = ReadVersion(my, sv); create && err != nil {
-		// only set default version if a version is not present
-		if err = setDefaultVersion(my, sv, version); err != nil {
-			return nil, err
+	if create {
+		log.Printf("# -> Force: %t", force)
+		if _, err = ReadVersion(my, sv); err != nil || force {
+			// set version if semantic version is not present or if force is set
+			if err = setDefaultVersion(my, sv, version); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

Adds the ability to overwrite existing semantic version via a force flag

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/git-semver/issues/41

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Unit tests were not added because the underlying data structure as it is currently defined has been deemed not testable. All the code added in this PR requires the underlying struct to be mocked which is virtually impossible. See the following closed PR for details regarding the testability of the underlying struct: https://github.com/edgexfoundry/git-semver/pull/37

**Functional Tests**
I executed functional tests to 
1. ensure the added functionality works as required and 
2. the previous functionality continued to work as expected. 

**Functional Test Results**
I used the following test repositories for the git-semver tests:  

https://github.com/soda480/test_us6132a
https://github.com/soda480/test_us6132b
https://github.com/soda480/test_us6132c

The stdout of the functional tests is included.
[test.output.txt](https://github.com/edgexfoundry/git-semver/files/4245871/test.output.txt)

**Summary**
| Test| Result|
| --- | --- |
| Init with invalid version should fail | Pass |
| Init with invalid usage should display usage | Pass |
| Init with valid version specified should set version | Pass |
| Init with no version specified should set default to 0.0.0 | Pass |
| Bump pre works as expected | Pass |
| Bump pre specfiy pre works as expected | Pass |
| Bump patch works as expected | Pass |
| Bump minor works as expected | Pass |
| Bump major works as expected | Pass |
| Tag works as expected | Pass |
| Push works as expected | Pass |
| Init after deleting .semver directory should retain upstream semver version | Pass |
| Init force set version when existing version exists | Pass |
| Test using SSH proxy | Pass |
| Test using no SSH proxy | Pass |
