### PR TITLE
Add ability to force tag HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This will bump the specified axis and commit the change to the semver branch. `f
 
 For example, if currently on the `master` branch and the value returned by `git semver` is `1.0.0` invoking `git semver bump -pre=rc patch` will result in `1.0.1-rc.1` written to `$PWD/.semver/master` and commited, the written to STDOUT.
 
-### `git semver tag`
+### `git semver tag [-force]`
 
-Attempt to tag the current HEAD with a tag that is effectively `v$(git semver)`. This will fail if `git-semver` detects a tag on the current HEAD that can be parsed as a Semantic Version.
+Attempt to tag the current HEAD with a tag that is effectively `v$(git semver)`. This will fail if `git-semver` detects a tag on the current HEAD that can be parsed as a Semantic Version, unless the `force` flag is specified. The `force` flag will tag the current HEAD regardless if there is an existing tag present on HEAD.
 
 ### `git semver push`
 

--- a/main.go
+++ b/main.go
@@ -15,15 +15,16 @@ import (
 )
 
 var (
-	dir     string
-	cli     = flag.NewFlagSet("git-semver", flag.ExitOnError)
-	_init   = flag.NewFlagSet("git-semver-init", flag.ExitOnError)
-	_bump   = flag.NewFlagSet("git-semver-bump", flag.ExitOnError)
-	_tag    = flag.NewFlagSet("git-semver-tag", flag.ExitOnError)
-	_push   = flag.NewFlagSet("git-semver-push", flag.ExitOnError)
-	pre     string
-	version string
-	force   *bool
+	dir       string
+	cli       = flag.NewFlagSet("git-semver", flag.ExitOnError)
+	_init     = flag.NewFlagSet("git-semver-init", flag.ExitOnError)
+	_bump     = flag.NewFlagSet("git-semver-bump", flag.ExitOnError)
+	_tag      = flag.NewFlagSet("git-semver-tag", flag.ExitOnError)
+	_push     = flag.NewFlagSet("git-semver-push", flag.ExitOnError)
+	pre       string
+	version   string
+	force     *bool
+	force_tag *bool
 )
 
 func init() {
@@ -63,6 +64,7 @@ func init() {
 	_init.StringVar(&version, "ver", "0.0.0", "the initial version (defaults to '0.0.0' if not specified)")
 	force = _init.Bool("force", false, "force set the specified version")
 	_bump.StringVar(&pre, "pre", "", "the pre-release prefix (defaults to 'pre' if not specified when bumping 'pre')")
+	force_tag = _tag.Bool("force", false, "force tag current HEAD with current semver version")
 
 	if err := cli.Parse(os.Args[1:]); err != nil {
 		fail(err, cli.Usage)
@@ -125,7 +127,7 @@ func main() {
 		// do 'git-semver tag'
 		cmd = _tag.Name()
 
-		if err = scope.Tag(my, sv); err != nil {
+		if err = scope.Tag(my, sv, *force_tag); err != nil {
 			log.Fatalf("%s: %v", cmd, err)
 		}
 	case _push.Parsed():

--- a/scope/tag.go
+++ b/scope/tag.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Tag the current HEAD with the current semver version.
-func Tag(my, sv *Extent) error {
+func Tag(my, sv *Extent, force bool) error {
 	tip, err := my.Repo.Head()
 	if err != nil {
 		return err
@@ -24,7 +24,8 @@ func Tag(my, sv *Extent) error {
 	if err != nil {
 		return err
 	}
-	if tag != nil {
+	log.Printf("# -> Force: %t", force)
+	if tag != nil && !force {
 		log.Printf("# %s", tag)
 		return fmt.Errorf("%s is already tagged: %s", tip.Hash().String()[:7], tag.Name().Short())
 	}


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

Add ability to force tag HEAD. With this PR git-semver will support the ability to force a tag to be written to HEAD regardless if HEAD is already tagged. This enhancement is required by EdgeX CD release automation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/git-semver/issues/45

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
Unit tests were not added because the underlying data structure as it is currently defined has been deemed not testable. All the code added in this PR requires the underlying struct to be mocked which is virtually impossible. See the following closed PR for details regarding the testability of the underlying struct: https://github.com/edgexfoundry/git-semver/pull/37

**Functional Tests**
I executed functional tests to 
1. ensure the added functionality works as required and 
2. the previous functionality continued to work as expected. 

**Functional Test Results**
I used the following test repositories for the git-semver tests:  

https://github.com/soda480/test_us6242a
https://github.com/soda480/test_us6242b

The stdout of the functional tests is included; test1 using proxy, test2 no proxy:
[test1.output.txt](https://github.com/edgexfoundry/git-semver/files/4278124/test1.output.txt)
[test2.output.txt](https://github.com/edgexfoundry/git-semver/files/4278125/test2.output.txt)

**Summary**
| Test| Result|
| --- | --- |
| Init with invalid version should fail | Pass |
| Init with invalid usage should display usage | Pass |
| Init with valid version specified should set version | Pass |
| Init with no version specified should set default to 0.0.0 | Pass |
| Bump pre works as expected | Pass |
| Bump pre specfiy pre works as expected | Pass |
| Bump patch works as expected | Pass |
| Bump minor works as expected | Pass |
| Bump major works as expected | Pass |
| Tag works as expected | Pass |
| Tag HEAD with existing tag fails | Pass |
| Tag force adds new tag to HEAD | Pass |
| Push works as expected | Pass |
| Init after deleting .semver directory should retain upstream semver version | Pass |
| Init force set version when existing version exists | Pass |
| Test using SSH proxy | Pass |
| Test using no SSH proxy | Pass |
