### PR TITLE
fix snyk scan high CVE & update files for go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.12-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE} as builder
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.12-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE}
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 edgeXBuildGoApp (
     project: 'git-semver',
-    goVersion: '1.12',
+    goVersion: '1.13',
     dockerImageName: 'git-semver',
     dockerNamespace: 'edgex-devops'
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/edgexfoundry/git-semver
 
+go 1.13
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 // indirect
-	gopkg.in/src-d/go-git.v4 v4.13.1
+	github.com/go-git/go-git/v5 v5.1.0
 )


### PR DESCRIPTION
Signed-off-by: Koppolu <venkata.subbareddy.koppolu@intel.com>

- Provide a fix to address the high CVE reported from snyk scan.
- Update required files in git-semver to go 1.13 version.
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
[#49](https://github.com/edgexfoundry/git-semver/issues/49)
## Sandbox Testing
Test Links :


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
### Functional Testing:
Functional testing has been done for the expected behavior of git-semver, with the change we have implemented to address [high CVE](https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-551923) reported by Snyk and for updating the go version.
Functional testing has been done over an existing repo(_test-git-semver_) and also on a complete new repo(_test-git-semver-new_)
#### Git repos used for testing:
https://github.com/venkata-subbareddyK/test-git-semver
https://github.com/venkata-subbareddyK/test-git-semver-new

[git-semver-functional-test-1.log](https://github.com/edgexfoundry/git-semver/files/4917481/git-semver-functional-test-1.log) : on a existing repo
[git-semver-functional-test-2.log](https://github.com/edgexfoundry/git-semver/files/4917484/git-semver-functional-test-2.log) : on a existing + new repo


#### Summary:

Test Case | Observed Result
-- | --
Init with invalid version should fail | PASS
Init with invalid usage should display usage | PASS
Init with valid version specified should set version | PASS
Init with no version specified should set default to 0.0.0 | PASS
Bump pre works as expected | PASS
Bump pre specfiy pre works as expected | PASS
Bump patch works as expected | PASS
Bump minor works as expected | PASS
Bump major works as expected | PASS
Tag works as expected | PASS
Tag HEAD with existing tag fails | PASS
Tag force adds new tag to HEAD | PASS
Push works as expected | PASS
