### PR TITLE
Fix: Go Version updated to v1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.13-alpine
+ARG BASE=golang:1.15-alpine
 FROM ${BASE} as builder
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.13-alpine
+ARG BASE=golang:1.15-alpine
 FROM ${BASE}
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 edgeXBuildGoApp (
     project: 'git-semver',
-    goVersion: '1.13',
+    goVersion: '1.15',
     dockerImageName: 'git-semver',
     dockerNamespace: 'edgex-devops'
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/edgexfoundry/git-semver
 
-go 1.13
+go 1.15
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/go-git/go-git/v5 v5.3.0
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 // indirect
-	github.com/go-git/go-git/v5 v5.1.0
 )

--- a/scope/init.go
+++ b/scope/init.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/blang/semver"
 
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/config"
-	"gopkg.in/src-d/go-git.v4/plumbing"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 // Init attempts to clone, but failing that will initialize, the semver orphan branch into .semver directory.

--- a/scope/open.go
+++ b/scope/open.go
@@ -7,10 +7,10 @@ package scope
 import (
 	"fmt"
 
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/storer"
-	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
 // Open the GIT "extent" located at path.

--- a/scope/push.go
+++ b/scope/push.go
@@ -5,8 +5,8 @@
 package scope
 
 import (
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/config"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 )
 
 // Push the semver branch and any tags to the remote.

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/blang/semver"
 
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
 var (

--- a/scope/tag.go
+++ b/scope/tag.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 // Tag the current HEAD with the current semver version.

--- a/scope/write.go
+++ b/scope/write.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 // WriteVersion writes the version string value to a file named after the current branch.


### PR DESCRIPTION
Fix: Go Version updated to v1.15
Updating all references of gopkg.in/src-d/go-git.v4 to github.com/go-git/go-git/v5

Signed-off-by: Chinu Joy <chinu.joy@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

**Functional Test Results**
I used the following test repositories for the git-semver tests:  

https://github.com/cjoyv/git-semver-US1184
https://github.com/cjoyv/test-US1184

The stdout of the functional tests is included

[git-semver-noproxy-tests.txt](https://github.com/edgexfoundry/git-semver/files/6378950/git-semver-noproxy-tests.txt)
[git-semver-tests.txt](https://github.com/edgexfoundry/git-semver/files/6378954/git-semver-tests.txt)


**Summary**
| Test| Result|
| --- | --- |
| Init with invalid version should fail | Pass |
| Init with invalid usage should display usage | Pass |
| Init with valid version specified should set version | Pass |
| Init with no version specified should set default to 0.0.0 | Pass |
| Bump pre works as expected | Pass |
| Bump pre specify pre works as expected | Pass |
| Bump patch works as expected | Pass |
| Bump minor works as expected | Pass |
| Bump major works as expected | Pass |
| Tag works as expected | Pass |
| Tag HEAD with existing tag fails | Pass |
| Tag force adds new tag to HEAD | Pass |
| Push works as expected | Pass |
| Init after deleting .semver directory should retain upstream semver version | Pass |
| Init force set version when existing version exists | Pass |
| Test using SSH proxy | Pass |
| Test using no SSH proxy | Pass |

