### PR TITLE
fix: integrate remote changes when detected prior to push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,6 @@ edgeXBuildDocker(
     dockerImageName: 'py-git-semver',
     dockerNamespace: 'edgex-devops',
     dockerNexusRepo: 'snapshots',
-    dockerTags: ['0.1.3'],
+    dockerTags: ['0.1.4'],
     releaseBranchOverride: 'python'
 )

--- a/build.py
+++ b/build.py
@@ -30,7 +30,7 @@ name = 'pygsver'
 authors = [Author('Emilio Reyes', 'emilio.reyes@intel.com')]
 summary = 'A Python script that manages semantic versioning of a git repository'
 url = 'https://github.com/edgexfoundry/git-semver/tree/python'
-version = '0.1.3'
+version = '0.1.4'
 default_task = [
     'clean',
     'analyze',

--- a/src/main/python/pygsver/push.py
+++ b/src/main/python/pygsver/push.py
@@ -26,6 +26,18 @@ def run_push(repo, settings=None):
     semver_path = settings['semver_path']
     semver_repo = Repo(semver_path)
     semver_remote_name = settings['semver_remote_name']
+
+    # pull remote if it has changed
+    local_commits = [commit.hexsha for commit in list(semver_repo.iter_commits())]
+    latest_remote_commit = semver_repo.remotes[semver_remote_name].fetch()[0].commit.hexsha
+    if latest_remote_commit not in local_commits:
+        logger.debug('remote changes detected')
+        logger.debug(f'latest remote commit {latest_remote_commit} is not in local commits')
+        logger.debug('integrating remote changes with a git pull')
+        semver_repo.git.pull(semver_remote_name, 'semver')
+    else:
+        logger.debug('no remote changes detected')
+
     semver_repo.git.push(semver_remote_name, 'semver')
 
     logger.debug('push all version tags')

--- a/src/unittest/python/test_push.py
+++ b/src/unittest/python/test_push.py
@@ -33,8 +33,15 @@ class TestPush(unittest.TestCase):
         pass
 
     @patch('pygsver.push.Repo')
-    def test__run_push_Should_CallExpected_When_Called(self, repo_patch, *patches):
-        semver_repo_mock = Mock()
+    def test__run_push_Should_CallExpected_When_NoRemoteChanges(self, repo_patch, *patches):
+        hex_mock = Mock(hexsha='123456abcdef')
+        commit_mock = Mock(commit=hex_mock)
+        remote_origin_mock = Mock()
+        remote_origin_mock.fetch.return_value = [commit_mock]
+        remotes_mock = {'origin': remote_origin_mock}
+        semver_repo_mock = Mock(remotes=remotes_mock)
+        semver_repo_mock.iter_commits.return_value = [Mock(hexsha='123456abcdef'), Mock(hexsha='commita'), Mock(hexsha='commitb')]
+
         repo_patch.return_value = semver_repo_mock
         settings = {
             'semver_remote_name': 'origin',
@@ -42,5 +49,27 @@ class TestPush(unittest.TestCase):
         }
         repo_mock = Mock()
         run_push(repo_mock, settings=settings)
+        self.assertTrue(call('origin', 'semver') not in semver_repo_mock.git.pull.mock_calls)
+        self.assertTrue(call('origin', 'semver') in semver_repo_mock.git.push.mock_calls)
+        self.assertTrue(call('origin', 'refs/tags/v*:refs/tags/v*') in repo_mock.git.push.mock_calls)
+
+    @patch('pygsver.push.Repo')
+    def test__run_push_Should_CallExpected_When_RemoteChanges(self, repo_patch, *patches):
+        hex_mock = Mock(hexsha='890123abcdef')
+        commit_mock = Mock(commit=hex_mock)
+        remote_origin_mock = Mock()
+        remote_origin_mock.fetch.return_value = [commit_mock]
+        remotes_mock = {'origin': remote_origin_mock}
+        semver_repo_mock = Mock(remotes=remotes_mock)
+        semver_repo_mock.iter_commits.return_value = [Mock(hexsha='commita'), Mock(hexsha='commitb')]
+
+        repo_patch.return_value = semver_repo_mock
+        settings = {
+            'semver_remote_name': 'origin',
+            'semver_path': '/repo/.semver'
+        }
+        repo_mock = Mock()
+        run_push(repo_mock, settings=settings)
+        self.assertTrue(call('origin', 'semver') in semver_repo_mock.git.pull.mock_calls)
         self.assertTrue(call('origin', 'semver') in semver_repo_mock.git.push.mock_calls)
         self.assertTrue(call('origin', 'refs/tags/v*:refs/tags/v*') in repo_mock.git.push.mock_calls)


### PR DESCRIPTION
for the `git semver push` operation check remote for changes; if remote changes detected then execute a git pull prior to doing a push.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X]  Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Reproduction of Issue:
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fsample-service/detail/main/50/pipeline/719

Functional Test - remote changes detected
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fsample-service/detail/main/62/pipeline/649

Functional Test - no remote changes detected:
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fsample-service/detail/main/61/pipeline/649

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
